### PR TITLE
fix: correct Discord invite link

### DIFF
--- a/notes/dev/CODE_OF_CONDUCT.md
+++ b/notes/dev/CODE_OF_CONDUCT.md
@@ -40,7 +40,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 - GitHub Issues: [Report an issue](https://github.com/Aemulus-XR/AemulusConnect/issues)
 - LinkedIn: [linkedin.com/in/scottkirvan/](https://www.linkedin.com/in/scottkirvan/)
-- Discord: [discord.gg/TSKHvVFYxB](https://discord.gg/TSKHvVFYxB)
+- Discord: [discord.gg/TN6XJSNK5Y](https://discord.gg/TN6XJSNK5Y)
 
 All complaints will be reviewed and investigated promptly and fairly.
 


### PR DESCRIPTION
Replaces incorrect invite code `TSKHvVFYxB` with correct `TN6XJSNK5Y` in CODE_OF_CONDUCT.md.